### PR TITLE
Add R model and simplify Stata code

### DIFF
--- a/notebooks/r_files/model.R
+++ b/notebooks/r_files/model.R
@@ -1,0 +1,13 @@
+library(dplyr)
+data <- read.csv('C:/Users/alexw/Documents/GitHub/tpp-sql-notebook/data/analysis/final_dataset.csv')
+
+ages <- pull(data, Age)
+age.cat <- cut(ages, breaks=c(0, 40, 70, 120), right = FALSE)
+data["age.cat"] <- age.cat
+
+
+model <- glm(died ~ Sex + age.cat + smoking_status + chd_code,
+             family=binomial(link='logit'),
+             data=data
+             )
+exp(coef(model))

--- a/notebooks/stata_files/model.do
+++ b/notebooks/stata_files/model.do
@@ -1,20 +1,7 @@
-import delimited /Users/carolinemorton/Documents/ebmdatalab/covid19/tpp-sql-notebook/data/analysis/final_dataset.csv
+clear
+import delimited C:/Users/alexw/Documents/GitHub/tpp-sql-notebook/data/analysis/final_dataset.csv
 
-/* final data cleaning
-- gender 
-- v1 
-*/
-
-
-drop v1
-
-gen gender = 2 if sex == "F"
-replace gender = 1 if sex == "M"
-
-label define gender 2 "female" 1 "male"
-label values gender gender
-
-drop sex
+encode sex, gen(gender)
 
 gen ageband = .
 replace ageband = 1 if age <40


### PR DESCRIPTION
I've changed the Stata file to use the `encode` function for sex (as it's one line instead of 4), which has also switched which group is 1 and which is 2. The order now matches the way that the R regression does it.

The R model output matches the odds ratios of the Stata model closely, but not exactly. Differences are possibly due to different ways that the model functions generate coefficients (though I can't really elaborate much). If we need them to match exactly, we can investigate further once we know with more certainty the model functions we're going to use.